### PR TITLE
Fixed issue ConfigurationSection.ToString returns type not representa…

### DIFF
--- a/src/QuickService.Common/Configuration/ConfigurationProvider.cs
+++ b/src/QuickService.Common/Configuration/ConfigurationProvider.cs
@@ -18,6 +18,7 @@ namespace QuickService.Common.Configuration
     using System.Fabric;
     using System.Fabric.Description;
     using System.IO;
+    using System.Linq;
     using System.Security;
     using System.Security.Cryptography;
     using System.Text;
@@ -228,7 +229,8 @@ namespace QuickService.Common.Configuration
                     {
                         // Get the section and calculate the hash.
                         ConfigurationSection section = sections[_serviceNameUri.AbsoluteUri];
-                        byte[] hash = md5.ComputeHash(Encoding.UTF8.GetBytes(section.ToString()));
+                        string sectionContent = string.Join("|", section.Parameters.Select(p => $"{p.Name}~{p.Value}"));
+                        byte[] hash = md5.ComputeHash(Encoding.UTF8.GetBytes(sectionContent));
 
                         if (false == CompareHashes(hash, _configSectionHash))
                         {


### PR DESCRIPTION
@toddabel, as discussed in [this issue](https://github.com/toddabel/PQService/issues/1), this PR fixes the issue where subsequent configuration loads (after the first initial load) wouldn't be recognized as changed. This was caused by the hash on the configuration being based on ConfigurationSection.ToString returning the type name, whereas the hash needs to include the key/value pairs to properly detect any changes. Before this PR fix, the initial load always works because the stored hash is null so any new hash is detected as different. But any subsequent changes are not detected as the hash is always the same.

I wanted to add a unit test for a subsequent configuration change but didn't have time to do so.

I thought this was an important fix, because there isn't much in the public domain on dynamic SF service configuration changes, and this is such an important/useful feature of the platform. This project provides a good example/starting point for others - thanks!